### PR TITLE
customize m2mToken by adding application properties

### DIFF
--- a/m2mToken/addApplicationPropertiesToM2MWorkflow.ts
+++ b/m2mToken/addApplicationPropertiesToM2MWorkflow.ts
@@ -1,0 +1,70 @@
+import {
+  onM2MTokenGeneratedEvent,
+  WorkflowSettings,
+  WorkflowTrigger,
+  createKindeAPI,
+  m2mTokenClaims,
+} from "@kinde/infrastructure";
+
+export const workflowSettings: WorkflowSettings = {
+  id: "m2mTokenGeneration",
+  name: "M2M custom claims",
+  failurePolicy: {
+    action: "stop",
+  },
+  trigger: WorkflowTrigger.M2MTokenGeneration,
+  bindings: {
+    "kinde.m2mToken": {},
+    "kinde.fetch": {},
+    "kinde.env": {},
+    "kinde.mfa": {},
+    url: {}
+  },
+};
+
+// This workflow requires you to set up the Kinde management API
+// You can do this by going to the Kinde dashboard.
+//
+// Create an M2M application with the following scopes enabled:
+// * read:application_properties
+// * read:applications
+//
+// In Settings -> Environment variables set up the following variables with the
+// values from the M2M application you created above:
+//
+// * KINDE_WF_M2M_CLIENT_ID
+// * KINDE_WF_M2M_CLIENT_SECRET - Ensure this is setup with sensitive flag
+// enabled to prevent accidental sharing
+//
+
+interface ApplicationProperty {
+  key: string;
+  value: any;
+  name: string;
+  description: string | null;
+  id: string;
+}
+
+interface ApplicationPropertiesClaim {
+  allAppProperties: Record<string, any>;
+}
+
+export default async function Workflow(event: onM2MTokenGeneratedEvent) {
+  let appProperties: ApplicationProperty[] = [];
+  try {
+    const kindeAPI = await createKindeAPI(event);
+    const { clientId } = event.context.application;
+    const { data } = await kindeAPI.get({
+      endpoint: `applications/${clientId}/properties`,
+    });
+    appProperties = data.properties ?? [];
+  } catch (err) {
+    console.error("Unable to fetch application properties", err);
+    // Optionally: decide whether to rethrow based on business rules
+  }
+
+  const m2mToken = m2mTokenClaims<ApplicationPropertiesClaim>();
+
+  // Filter and process properties before assigning to token
+  m2mToken.allAppProperties = appProperties;
+}


### PR DESCRIPTION
Added a new example for m2mToken customization. I tried to add app properties using m2mCustomClaim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Application properties are now automatically added as custom claims to machine-to-machine (M2M) tokens when they are generated. This enhances token content with relevant application details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->