### PR TITLE
Trustpath impossible travel

### DIFF
--- a/postUserAuthentication/impossibleTravelWorkflow.ts
+++ b/postUserAuthentication/impossibleTravelWorkflow.ts
@@ -1,32 +1,41 @@
 import { onPostAuthenticationEvent, denyAccess, createKindeAPI } from "@kinde/infrastructure";
 
+export const workflowSettings = {
+  id: "impossibleTravelCheck",
+  trigger: "user:post_authentication",
+  bindings: {
+    "kinde.auth": {},
+    "kinde.secureFetch": {}
+  }
+};
+
 export default onPostAuthenticationEvent(async (event) => {
   const kindeAPI = await createKindeAPI(event);
-  const { data: user } = await kindeAPI.get({endpoint: `user?id=${event.context.user.id}`});
+  const { data: user } = await kindeAPI.get({ endpoint: `user?id=${event.context.user.id}` });
 
-  const tpKey = process.env.TRUSTPATH_API_KEY!;
-  const eventType = event.context.auth.isNewUserRecordCreated ? "account_register" : "account_login";
-
-  const ip = event.request.ip.split(",")[0].trim();
   const payload = {
-    ip,
+    ip: event.request.ip.split(",")[0].trim(),
     email: user.preferred_email,
     user: {
       user_id: event.context.user.id,
       first_name: user.first_name,
       last_name: user.last_name
     },
-    event_type: eventType
+    event_type: event.context.auth.isNewUserRecordCreated
+      ? "account_register"
+      : "account_login"
   };
 
-  const resp = await kinde.fetch("https://api.trustpath.io/v1/risk/evaluate", {
+  const resp = await kinde.secureFetch("https://api.trustpath.io/v1/risk/evaluate", {
     method: "POST",
-    headers: { Authorization: `Bearer ${tpKey}`, "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-    responseFormat: "json"
+    headers: { 
+      Authorization: `Bearer ${process.env.TRUSTPATH_API_KEY}`, 
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
   });
 
-  const state = resp.json.data.score.state;
+  const { state } = (await resp.json()).data.score;
   if (state === "decline") {
     denyAccess("Access blocked due to impossible travel risk.");
   }

--- a/postUserAuthentication/impossibleTravelWorkflow.ts
+++ b/postUserAuthentication/impossibleTravelWorkflow.ts
@@ -1,0 +1,33 @@
+import { onPostAuthenticationEvent, denyAccess, createKindeAPI } from "@kinde/infrastructure";
+
+export default onPostAuthenticationEvent(async (event) => {
+  const kindeAPI = await createKindeAPI(event);
+  const { data: user } = await kindeAPI.get({endpoint: `user?id=${event.context.user.id}`});
+
+  const tpKey = process.env.TRUSTPATH_API_KEY!;
+  const eventType = event.context.auth.isNewUserRecordCreated ? "account_register" : "account_login";
+
+  const ip = event.request.ip.split(",")[0].trim();
+  const payload = {
+    ip,
+    email: user.preferred_email,
+    user: {
+      user_id: event.context.user.id,
+      first_name: user.first_name,
+      last_name: user.last_name
+    },
+    event_type: eventType
+  };
+
+  const resp = await kinde.fetch("https://api.trustpath.io/v1/risk/evaluate", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${tpKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    responseFormat: "json"
+  });
+
+  const state = resp.json.data.score.state;
+  if (state === "decline") {
+    denyAccess("Access blocked due to impossible travel risk.");
+  }
+});


### PR DESCRIPTION
# Explain your changes

This PR adds a `postUserAuthentication` workflow that integrates with Trustpath to perform an impossible travel risk evaluation on user login or registration.

- It uses `createKindeAPI` to fetch the authenticated user's profile data.
- Constructs a payload including user email, ID, name, and client IP.
- Sends a POST request to Trustpath's risk evaluation endpoint.
- If Trustpath returns a `state` of `"decline"` in the response, access is denied using `denyAccess`.

This helps proactively block suspicious logins and improve account protection.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
