### PR TITLE
feat: add workflow to sync SAML attributes into Kinde user properties

### DIFF
--- a/postUserAuthentication/syncAttributesSamlWorkflow.ts
+++ b/postUserAuthentication/syncAttributesSamlWorkflow.ts
@@ -57,7 +57,7 @@ const attributeSyncConfig = [
 ];
 
 export default async function handlePostAuth(event: onPostAuthenticationEvent) {
-    const protocol = event.context.auth.provider.protocol;
+    const protocol = event.context?.auth?.provider?.protocol;
     if (!protocol || protocol !== "saml") return;
 
     const attributeStatements =

--- a/postUserAuthentication/syncAttributesSamlWorkflow.ts
+++ b/postUserAuthentication/syncAttributesSamlWorkflow.ts
@@ -1,0 +1,105 @@
+import {
+    onPostAuthenticationEvent,
+    WorkflowSettings,
+    WorkflowTrigger,
+    createKindeAPI,
+} from "@kinde/infrastructure";
+
+// This workflow syncs user attributes and groups from a SAML assertion into Kinde custom user properties.
+// It works with any SAML connection, as long as attributes and groups are exposed in the SAML response.
+//
+// Setup steps:
+//
+// 1. In your Identity Provider (IdP), configure SAML attribute statements / group attribute statements
+//    to send the attributes you want to sync.
+//
+// 2. In Kinde, create custom user property keys to store these attributes:
+//    * phone_number
+//    * user_type
+//    * groups
+//
+//    Note: Update the `attributeSyncConfig` object in the code below if your IdP uses different names.
+//
+// 3. Create an M2M application in Kinde with the following scope enabled:
+//    * update:user_properties
+//
+//    In Settings -> Environment variables, configure the following (values from your M2M application):
+//    * KINDE_WF_M2M_CLIENT_ID
+//    * KINDE_WF_M2M_CLIENT_SECRET  (mark as sensitive)
+//
+// 4. Ensure the properties are included in tokens by toggling OFF the “Private” option in their settings.
+//    Then, in the Application settings in Kinde, add them under **Token customization**.
+//
+// Once configured, this workflow will run after authentication, read the attributes from the SAML assertion,
+// and sync them into Kinde so they can be used in tokens or elsewhere.
+
+export const workflowSettings: WorkflowSettings = {
+    id: "postAuthentication",
+    name: "SamlAttributesSync",
+    failurePolicy: {
+        action: "stop",
+    },
+    trigger: WorkflowTrigger.PostAuthentication,
+    bindings: {
+        "kinde.env": {},
+        url: {},
+    },
+};
+
+type SamlValue = { value?: string };
+type SamlAttribute = { name?: string; values?: SamlValue[] };
+type SamlAttributeStatement = { attributes?: SamlAttribute[] };
+
+const attributeSyncConfig = [
+    { samlName: "phone_number", kindeKey: "phone_number", multiValue: false },
+    { samlName: "user_type", kindeKey: "user_type", multiValue: false },
+    { samlName: "groups", kindeKey: "groups", multiValue: true },
+];
+
+export default async function handlePostAuth(event: onPostAuthenticationEvent) {
+    const protocol = event.context.auth.provider.protocol;
+    if (!protocol || protocol !== "saml") return;
+
+    const attributeStatements =
+        event.context.auth.provider?.data?.assertion
+            ?.attributeStatements as SamlAttributeStatement[] | undefined;
+    if (!attributeStatements?.length) return;
+
+    const samlAttributesMap = (attributeStatements ?? [])
+        .flatMap((statement) => statement.attributes ?? [])
+        .reduce((acc, attr) => {
+            const name = attr.name?.toLowerCase().trim();
+            if (name) {
+                const values = (attr.values ?? [])
+                    .map((v) => v.value?.trim())
+                    .filter((v): v is string => !!v);
+                if (values.length > 0) {
+                    acc.set(name, values);
+                }
+            }
+            return acc;
+        }, new Map<string, string[]>());
+
+    const propertiesToUpdate: Record<string, string> = {};
+
+    for (const config of attributeSyncConfig) {
+        const values = samlAttributesMap.get(config.samlName);
+        if (values && values.length > 0) {
+            if (config.multiValue) {
+                propertiesToUpdate[config.kindeKey] = values.join(",");
+            } else {
+                propertiesToUpdate[config.kindeKey] = values[0];
+            }
+        }
+    }
+
+    if (Object.keys(propertiesToUpdate).length === 0) return;
+
+    const kindeAPI = await createKindeAPI(event);
+    const userId = event.context.user.id;
+
+    await kindeAPI.patch({
+        endpoint: `users/${userId}/properties`,
+        params: { properties: propertiesToUpdate },
+    });
+}


### PR DESCRIPTION
# Explain your changes

_This workflow syncs user attributes (phone_number, user_type, groups) from any SAML connection into Kinde custom user properties after authentication.

It works with any IdP that exposes attributes/groups in the SAML response._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a post-authentication workflow that, for SAML logins, automatically syncs selected SAML assertion attributes into user profile properties.
  * Supported attributes: phone number, user type (single value), and groups (multi-value joined by commas).
  * Runs only for SAML, updates user properties when attributes exist, and skips otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->