### PR TITLE
PR: Add workflow to include billing info in user tokens - B2B case

### DIFF
--- a/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
+++ b/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
@@ -124,9 +124,9 @@ export default async function OrganizationBillingWorkflow(event: WorkflowEvent) 
 
         // [1] Get Organization Details (with Billing expanded)
         // Endpoint: GET /api/v1/organization/{org_code}?expand=billing
-        const { data: orgData } = await kindeAPI.get<OrganizationResponse>({
+        const { data: orgData } = (await kindeAPI.get({
             endpoint: `organization?code=${orgCode}&expand=billing`
-        });
+        })) as { data: OrganizationResponse }; 
 
         const customerId = orgData?.billing?.billing_customer_id ?? null;
         let initialAgreements = ensureArray<Agreement>(orgData?.billing?.agreements);
@@ -141,9 +141,10 @@ export default async function OrganizationBillingWorkflow(event: WorkflowEvent) 
         // - GET /api/v1/billing/entitlements?customer_id={id}&expand=plans
         // - GET /api/v1/billing/agreements?customer_id={id}
         const [entResp, agrResp] = await Promise.all([
-            kindeAPI.get<EntitlementsResponse>({
+            kindeAPI.get({
                 endpoint: `billing/entitlements?customer_id=${customerId}&expand=plans`
-            }),
+            }) as Promise<{ data: EntitlementsResponse }>,
+            
             // Only call agreements if we could not get it from the previous call
             initialAgreements.length === 0
             ? kindeAPI.get<AgreementsResponse>({

--- a/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
+++ b/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
@@ -1,0 +1,177 @@
+import { 
+    createKindeAPI, 
+    WorkflowSettings, 
+    WorkflowTrigger,
+} from "@kinde/infrastructure";
+
+export const workflowSettings: WorkflowSettings = {
+    id: "onTokenGenerationB2B",
+    name: "AddBillingDetailsToTokensB2B",
+    trigger: WorkflowTrigger.UserTokenGeneration,
+    failurePolicy: {
+        action: "stop"
+    },
+    bindings: {
+        "kinde.accessToken": {},
+        "kinde.idToken": {},
+        "kinde.env": {}, 
+        url: {} 
+    }
+};
+
+// --- Types ---
+interface WorkflowEvent {
+    context: {
+        user: {
+            id: string;
+        };
+        organization: {
+            code: string;
+        };
+    };
+    request?: unknown;
+}
+
+interface OrganizationResponse {
+    code?: string;
+    name?: string;
+    billing?: {
+        customer_id?: string;
+        has_payment_details?: boolean;
+        [key: string]: unknown;
+    };
+    [k: string]: unknown;
+}
+
+interface Entitlement {
+    feature_code?: string;
+    feature_name?: string;
+    limit_max?: number;
+    limit_min?: number;
+    [k: string]: unknown;
+}
+
+interface EntitlementsResponse {
+    entitlements?: Entitlement[];
+    [k: string]: unknown;
+}
+
+interface Agreement {
+    id?: string;
+    plan_code?: string;
+    expires_on?: string;
+    [k: string]: unknown;
+}
+
+interface AgreementsResponse {
+    agreements?: Agreement[];
+    [k: string]: unknown;
+}
+
+interface OrgBillingClaim {
+    customer_id: string | null;
+    org_billing: OrganizationResponse['billing'];
+    entitlements: Entitlement[];
+    agreements: Agreement[];
+}
+
+// --- Helpers ---
+const ensureArray = <T,>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : []);
+
+
+/**
+ * Token generation workflow (B2B) to add Organization billing details to tokens.
+ * It identifies the current organization context, retrieves that org's billing data,
+ * entitlements, and agreements, and injects them as a custom claim.
+ * 
+ * 
+ *  Requirements:
+ * 
+ * 1. Create an M2M application in Kinde with these scopes:
+ *      - read:organizations         (To fetch org details + billing info)
+ *      - read:billing_entitlements  (To access entitlements)
+ *      - read:billing_agreements    (To access agreements)
+ * 
+ * 2. Add M2M Client ID & Secret to Kinde Environment Variables:
+ *      - KINDE_WF_M2M_CLIENT_ID 
+ *      - KINDE_WF_M2M_CLIENT_SECRET (Sensitive)
+ * 
+ *      Docs: https://docs.kinde.com/build/env-variables/store-environment-variables/
+ * 
+ * 3. Execution context:
+ * - This workflow expects the user to be logging into a specific organization 
+ * (event.context.organization.code must be present).
+ * 
+ * @param event - The event object containing user and organization context.
+ * @returns <void> - This function does not return a value, but the custom claims are set in the tokens 
+ *
+ */
+export default async function OrganizationBillingWorkflow(event: WorkflowEvent) {
+    try {
+        console.log("Starting B2B Billing Token Workflow...");
+
+        // [0] Validate Organization Context
+        // In B2B, we only care about the org the user is currently signing into.
+        const orgCode = event.context?.organization?.code;
+
+        if (!orgCode) {
+            console.warn("No Organization Code found in context. Skipping B2B billing workflow.");
+            // We return early because this might be a personal/user-context login, 
+            // where org billing data is irrelevant.
+            return;
+        }
+
+        const kindeAPI = await createKindeAPI(event);
+
+        // [1] Get Organization Details (with Billing expanded)
+        // Endpoint: GET /api/v1/organization/{org_code}?expand=billing
+        const { data: orgData } = await kindeAPI.get<OrganizationResponse>({
+            endpoint: `organization?code=${orgCode}&expand=billing`
+        });
+
+        const customerId = orgData?.billing?.billing_customer_id ?? null;
+        let initialAgreements = ensureArray<Agreement>(orgData?.billing?.agreements);
+
+        if (!customerId) {
+            console.info(`No billing customer ID found for Org ${orgCode}. Skipping claim.`);
+            return;
+        }
+
+        // [2] Fetch Entitlements & Agreements in parallel
+        // Endpoints: 
+        // - GET /api/v1/billing/entitlements?customer_id={id}&expand=plans
+        // - GET /api/v1/billing/agreements?customer_id={id}
+        const [entResp, agrResp] = await Promise.all([
+            kindeAPI.get<EntitlementsResponse>({
+                endpoint: `billing/entitlements?customer_id=${customerId}&expand=plans`
+            }),
+            // Only call agreements if we could not get it from the previous call
+            !initialAgreements
+            ? kindeAPI.get<AgreementsResponse>({
+                endpoint: `billing/agreements?customer_id=${customerId}`
+            }): Promise.resolve(null)  
+        ]);
+
+        const entitlements = ensureArray<Entitlement>(entResp?.data?.entitlements);
+        const agreements = agrResp?.data?.agreements || initialAgreements;
+
+        // [3] Construct the B2B Billing Claim Object
+        const billingClaimObject: OrgBillingClaim = {
+            customer_id: customerId,
+            entitlements,
+            agreements
+        };
+
+        // [4] Set Custom Claims
+        // We inject this data into the tokens so the frontend/API can enforce limits immediately.
+        kinde.accessToken.setCustomClaim("org_billing", billingClaimObject);
+        kinde.idToken.setCustomClaim("org_billing", billingClaimObject);
+
+        console.log(`Successfully set 'org_billing' claim for Org: ${orgCode}`);
+
+    } catch (err) {
+        // Log error but respect the failurePolicy (stop/fail secure)
+        console.error("B2B Workflow Error:", (err as Error).message ?? err);
+        throw err;
+    }
+}

--- a/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
+++ b/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
@@ -70,7 +70,6 @@ interface AgreementsResponse {
 
 interface OrgBillingClaim {
     customer_id: string | null;
-    org_billing: OrganizationResponse['billing'];
     entitlements: Entitlement[];
     agreements: Agreement[];
 }
@@ -146,14 +145,15 @@ export default async function OrganizationBillingWorkflow(event: WorkflowEvent) 
                 endpoint: `billing/entitlements?customer_id=${customerId}&expand=plans`
             }),
             // Only call agreements if we could not get it from the previous call
-            !initialAgreements
+            initialAgreements.length === 0
             ? kindeAPI.get<AgreementsResponse>({
                 endpoint: `billing/agreements?customer_id=${customerId}`
             }): Promise.resolve(null)  
         ]);
 
         const entitlements = ensureArray<Entitlement>(entResp?.data?.entitlements);
-        const agreements = agrResp?.data?.agreements || initialAgreements;
+        const agreements =
++            agrResp?.data?.agreements ? ensureArray<Agreement>(agrResp.data.agreements) : initialAgreements;
 
         // [3] Construct the B2B Billing Claim Object
         const billingClaimObject: OrgBillingClaim = {

--- a/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
+++ b/userTokens/addBillingDetailsToTokensB2BWorkflow.ts
@@ -36,7 +36,7 @@ interface OrganizationResponse {
     code?: string;
     name?: string;
     billing?: {
-        customer_id?: string;
+        billing_customer_id?: string;
         has_payment_details?: boolean;
         [key: string]: unknown;
     };


### PR DESCRIPTION

# Explain your changes

**Summary**
Adds a B2B-specific workflow that fetches the active **Organization’s** billing information during token generation and adds it to the user tokens as an `org_billing` custom claim.

The workflow validates that an organization context exists, fetches the organization's billing profile via the Kinde Management API, retrieves entitlements and agreements in parallel, and gracefully handles errors or missing contexts.

**Files changed**

* `addBillingDetailsToTokensB2B.ts` (new workflow implementation)

**What this implements**

* Runs on the `user:tokens_generation` event and sets the `org_billing` claim on both access and ID tokens.
* Validates the execution context:
    * Checks if `event.context.organization.code` exists.
    * Skips execution/logging if the user is not signing into an organization context.
* Calls the appropriate Management APIs:
    * `GET /organization?code={code}&expand=billing` (to get the Org's `customer_id`)
    * `GET /billing/entitlements?customer_id=...`
    * `GET /billing/agreements?customer_id=...`
* Includes the **full organization billing payload** in the claim.
* Adds TypeScript types for `OrganizationResponse`, `OrgBillingClaim`, `Entitlement`, and `Agreement`.
* Implements parallel data fetching (`Promise.all`) for entitlements and agreements to minimize latency (<2s execution target).

**Notes & follow-ups**

* **Token size:** Similar to the B2C workflow, this implementation injects the raw billing payload. For organizations with massive entitlement lists, we may need to implement summary/filtering logic in a future PR to avoid hitting the 4KB header limit.
* **Separation of Concerns:** This workflow is distinct from the B2C workflow. It specifically isolates *Organization* data, ensuring users don't inadvertently get personal billing claims when logging into a business context (and vice versa).

---

# Checklist

- [X] I have read the [[“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests)](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [[contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md)](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [[code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md)](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [[Kinde community](https://thekindecommunity.slack.com/)](https://thekindecommunity.slack.com)._


## Summary by CodeRabbit

* **New Features**
  * Adds an `org_billing` custom claim to access and ID tokens when a user signs into an Organization.
  * Includes the Organization's customer ID, billing profile, entitlements, and agreements in the token payload.
  * Logic includes a check for organization context, skipping the billing fetch if the user is not signing into an organization.

* **Performance**
  * Implements parallel fetching of agreements and entitlements to ensure minimal impact on authentication latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a B2B token enrichment workflow that injects organization billing details (customer ID, entitlements, agreements) into identity and access tokens.
  * Handles missing data gracefully and performs efficient backend retrievals to minimize latency.
  * Workflow is available for use in token issuance to support downstream billing and access enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->